### PR TITLE
Do not call realpath on root when inside a phar

### DIFF
--- a/src/DocumentRoot.php
+++ b/src/DocumentRoot.php
@@ -78,7 +78,11 @@ final class DocumentRoot implements RequestHandler, ServerObserver {
             );
         }
 
-        $this->root = \rtrim(\realpath($root), "/");
+        if (\strncmp($root, "phar://", 7) !== 0) {
+            $root = \realpath($root);
+        }
+
+        $this->root = \rtrim($root, "/");
         $this->filesystem = $filesystem ?: File\filesystem();
         $this->multipartBoundary = \uniqid("", true);
     }


### PR DESCRIPTION
`realpath` calls fail when trying to run on entries inside a phar.

This PR only does the `realpath` call when not in a phar
