### PR TITLE
Fix a bug in DocumentRoot::coalesceIndexPath

### DIFF
--- a/src/DocumentRoot.php
+++ b/src/DocumentRoot.php
@@ -261,6 +261,7 @@ final class DocumentRoot implements RequestHandler, ServerObserver
         $dirPath = \rtrim($dirPath, "/") . "/";
         foreach ($this->indexes as $indexFile) {
             $coalescedPath = $dirPath . $indexFile;
+            File\StatCache::clear($coalescedPath);
             if (yield $this->filesystem->isfile($coalescedPath)) {
                 $stat = yield $this->filesystem->stat($coalescedPath);
                 return [$coalescedPath, $stat];


### PR DESCRIPTION
if the requesturi is "/", then clear the filesystem cache for
all index files before you get the file statistics for each index file